### PR TITLE
Add option to disable output of local deps

### DIFF
--- a/src/mach/pack/alpha/skinny.clj
+++ b/src/mach/pack/alpha/skinny.clj
@@ -80,10 +80,8 @@
               :paths (filter 
                       (fn [{:keys [path] :as f}]
                         (if (and aot (:local/root all))
-                          (do 
-                            (println path)
-                            (not (-> (last path)
-                                     (string/ends-with? ".clj"))))
+                          (not (-> (last path)
+                                   (string/ends-with? ".clj")))
                           true))
                       (vfs/files-path (file-seq (io/file path))
                                       (io/file path)))


### PR DESCRIPTION
Adds an `--aot` flag to the skinny entrypoint to exclude `.clj` files from `:local/root` dependencies at build time.

Having both `.clj` files and AOT byte-compiled classes on the class path seems to be the root cause of build issues related to `defprotocol` errors.

>The loader class is generated for each file referenced when a namespace is compiled, when its loader .class file is older than its source.

[source](https://clojure.org/reference/compilation) seems to indicated that we could be affected due to timing issues.  I am not 100% all the necessary Clojure files will be byte-compiled, and therefore if omitting CLJ source is entirely OK.  The next phase of this ticket will be to test build-artifacts against our integration tests.  Note that this is not currently supported - we test the code before building the artifact, but in this case we must test the artifact itself.